### PR TITLE
Add expat-devel package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG gopan_tag_version=v${gopan_version}
 RUN dnf update && \
     dnf upgrade -y && \
     dnf groupinstall -y "Development Tools" && \
-    dnf install -y awscli-2 git gzip openssl openssl-devel tar
+    dnf install -y awscli-2 expat-devel git gzip openssl openssl-devel tar
 
 # Install vendor packages for build-time Perl compilation tests
 RUN yum install -y procps-ng

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The following list details the distribution-managed packages installed in the co
 | `awscli-2`            | Used to retrieve non distribution-managed dependency packages from the S3 release bucket               |
 | `git`, `tar`, `unzip` | Required for working with `git` submodules as well as `.zip` and `.tar.gz` files during service builds |
 | `@Development tools`, `procps-ng` | Required when building Perl from source and during service builds for compiled modules     |
+| `expat-devel`         | Required dependency of `XML::Parser` Perl module                                                       |
 | `openssl`, `openssl-devel` | SSL libraries used by multiple tools and Perl modules                                             |
 | `perl-ExtUtils-MakeMaker` `perl-deprecate` | Required dependencies of [Perlbrew](https://perlbrew.pl/)                         |
 
@@ -31,3 +32,4 @@ In addition to the distribution-managed packages detailed above, the following t
 | Name                                             | Purpose                                                                            |
 |--------------------------------------------------|------------------------------------------------------------------------------------|
 | [GoPAN](https://github.com/companieshouse/gopan) | Used to retrieve private and external dependencies when building `*-deps` projects |
+| `Test::Harness` Perl module                      | TAP test harness used for running service unit tests (via the `prove` command)     |


### PR DESCRIPTION
The `expat-devel` libraries are a required dependency of `XML::Parser` which is a transitive dependency in the `api.ch.gov.uk-deps` build.