### PR TITLE
Reduce container image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ RUN source /opt/perlbrew/etc/bashrc && \
     perlbrew install -v perl-${perl_version} ${perl_build_args} && \
     perlbrew install-cpanm -v && \
     perlbrew use perl-${perl_version} && \
-    cpanm Test::Harness
+    cpanm Test::Harness && \
+    perlbrew clean
 
 # Set local time zone
 RUN unlink /etc/localtime && ln -s /usr/share/zoneinfo/Europe/London /etc/localtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,9 @@ ARG gopan_tag_version=v${gopan_version}
 RUN dnf update && \
     dnf upgrade -y && \
     dnf groupinstall -y "Development Tools" && \
-    dnf install -y awscli-2 expat-devel git gzip openssl openssl-devel tar
-
-# Install vendor packages for build-time Perl compilation tests
-RUN yum install -y procps-ng
-
-# Install vendor packages to support Perlbrew installation
-RUN yum install -y perl-ExtUtils-MakeMaker perl-deprecate
+    dnf install -y awscli-2 expat-devel git gzip openssl openssl-devel tar procps-ng perl-ExtUtils-MakeMaker perl-deprecate && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf /tmp/*
 
 # Install GoPAN for dependency resolution
 ADD https://github.com/companieshouse/gopan/releases/download/${gopan_tag_version}/gopan-${gopan_version}-linux_amd64.tar.gz /gopan-${gopan_version}-linux_amd64.tar.gz


### PR DESCRIPTION
These changes reduce the overall container image size by:

- Consolidating `dnf` commands into a single directive and removing cached files after installing packages
- Removing Perlbrew source distributions after installation of Perl