### PR TITLE
Add missing shared libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG gopan_tag_version=v${gopan_version}
 # Update system packages and install build tooling
 RUN dnf update && \
     dnf upgrade -y && \
-    dnf install -y gcc gcc-c++ bzip2 patch awscli-2 expat-devel git gzip openssl openssl-devel tar procps-ng perl-ExtUtils-MakeMaker perl-deprecate && \
+    dnf install -y gcc gcc-c++ bzip2 patch awscli-2 expat-devel git gzip openssl openssl-devel tar procps-ng perl-ExtUtils-MakeMaker perl-deprecate libzip && \
     dnf clean all && \
     rm -rf /var/cache/dnf /tmp/*
 


### PR DESCRIPTION
As a result of [removal of tooling](https://github.com/companieshouse/ci-perl-build-ecs/pull/5) to reduce the overall container image size, some shared libraries are no longer present, leading to build failures. This change reintroduces the `libzip` package which resolves build failures with the `IO::Socket::SSL` and `Net::SSLeay` dependencies.