### PR TITLE
Add zlib-devel package as a dependency of Net::SSLeay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG gopan_tag_version=v${gopan_version}
 # Update system packages and install build tooling
 RUN dnf update && \
     dnf upgrade -y && \
-    dnf install -y gcc gcc-c++ bzip2 patch awscli-2 expat-devel git gzip openssl openssl-devel tar procps-ng perl-ExtUtils-MakeMaker perl-deprecate libzip && \
+    dnf install -y gcc gcc-c++ bzip2 patch awscli-2 expat-devel git gzip openssl openssl-devel tar procps-ng perl-ExtUtils-MakeMaker perl-deprecate zlib-devel && \
     dnf clean all && \
     rm -rf /var/cache/dnf /tmp/*
 


### PR DESCRIPTION
This change replaces `libzip` with `zlib-devel` to ensure that both shared objects and header files are available for `Net::SSLeay` during the build process. 